### PR TITLE
Prevent method conflict: add mod prefix to private Mixin method

### DIFF
--- a/src/main/java/com/kamth/zeldamod/mixin/MixinLivingEntity.java
+++ b/src/main/java/com/kamth/zeldamod/mixin/MixinLivingEntity.java
@@ -35,7 +35,7 @@ public abstract class MixinLivingEntity {
     @Shadow public abstract boolean addEffect(MobEffectInstance pEffectInstance);
 
     @Unique
-    private LivingEntity getLivingEntity() {
+    private LivingEntity zeldaMod_getLivingEntity() {
         return (LivingEntity) (Object) this;
     }
 
@@ -66,10 +66,10 @@ public abstract class MixinLivingEntity {
 
     @Inject(method = "getBlockSpeedFactor", at = @At("HEAD"), cancellable = true)
     private void onGetBlockSpeedFactor(CallbackInfoReturnable<Float> cir) {
-        if (getLivingEntity().getItemBySlot(EquipmentSlot.FEET).getItem() == ZeldaItems.HOVER_BOOTS.get()) {
+        if (zeldaMod_getLivingEntity().getItemBySlot(EquipmentSlot.FEET).getItem() == ZeldaItems.HOVER_BOOTS.get()) {
             cir.setReturnValue(.96F);
         }
-        if (getLivingEntity().getItemBySlot(EquipmentSlot.HEAD).getItem() == ZeldaItems.GORON_MASK.get()) {
+        if (zeldaMod_getLivingEntity().getItemBySlot(EquipmentSlot.HEAD).getItem() == ZeldaItems.GORON_MASK.get()) {
             cir.setReturnValue(.97F);
         }
     }


### PR DESCRIPTION
The private method getLivingEntity() in this Mixin, even with @Unique, can cause AbstractMethodError if other mods (like EasyNPC) expect a default interface method with the same name.

See: https://github.com/MarkusBordihn/BOs-Easy-NPC/issues/538

Best practice:
Always add a mod-specific prefix to private utility methods in Mixins (for example: zeldaMod_selfAsLivingEntity()) to avoid conflicts with Minecraft or other mods.